### PR TITLE
feat: zustand 도입, useModalStore 세팅(#25)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
     "next": "16.0.10",
     "react": "19.2.1",
     "react-dom": "19.2.1",
+    "storybook": "^10.1.10",
     "tailwind-merge": "^3.4.0",
     "tailwind-variants": "^3.2.2",
-    "storybook": "^10.1.10"
+    "zustand": "^5.0.9"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       tailwind-variants:
         specifier: ^3.2.2
         version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.1.18)
+      zustand:
+        specifier: ^5.0.9
+        version: 5.0.9(@types/react@19.2.7)(react@19.2.1)(use-sync-external-store@1.6.0(react@19.2.1))
     devDependencies:
       '@commitlint/cli':
         specifier: ^20.2.0
@@ -3241,6 +3244,24 @@ packages:
 
   zod@4.2.1:
     resolution: {integrity: sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==}
+
+  zustand@5.0.9:
+    resolution: {integrity: sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -6553,3 +6574,9 @@ snapshots:
       zod: 4.2.1
 
   zod@4.2.1: {}
+
+  zustand@5.0.9(@types/react@19.2.7)(react@19.2.1)(use-sync-external-store@1.6.0(react@19.2.1)):
+    optionalDependencies:
+      '@types/react': 19.2.7
+      react: 19.2.1
+      use-sync-external-store: 1.6.0(react@19.2.1)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-import ThemeToggleButton from '@/components/ThemeToggleButton';
 import Text from '@/components/ui/Text';
 
 export default function Home() {
@@ -13,7 +12,6 @@ export default function Home() {
             </Text.M12>
             <Text.Body16 className="text-gray-600">{'<Text.Body16>'}</Text.Body16>
           </div>
-          <ThemeToggleButton />
         </div>
         <div className="flex flex-wrap gap-3">
           <span className="rounded-full bg-primary-100 px-3 py-1 text-sm text-primary">

--- a/src/shared/providers/theme-provider.tsx
+++ b/src/shared/providers/theme-provider.tsx
@@ -2,6 +2,8 @@
 
 import { createContext, useContext, useEffect, useState } from 'react';
 
+import ThemeToggleButton from '@/components/ThemeToggleButton';
+
 export type Theme = 'light' | 'dark';
 
 type ThemeContextValue = {
@@ -29,7 +31,12 @@ export const ThemeProvider = ({ initialTheme, children }: ThemeProviderProps) =>
     setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
   };
 
-  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+      <ThemeToggleButton />
+    </ThemeContext.Provider>
+  );
 };
 
 export const useTheme = () => {

--- a/src/shared/ui/useModalStore.ts
+++ b/src/shared/ui/useModalStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+type ModalState = {
+  isModalOpen: boolean;
+  openModal: () => void;
+  closeModal: () => void;
+};
+
+export const useModalStore = create<ModalState>((set) => ({
+  isModalOpen: false,
+  openModal: () => set({ isModalOpen: true }),
+  closeModal: () => set({ isModalOpen: false }),
+}));


### PR DESCRIPTION
## 📌 PR 개요

- zustand 및 모달 사용을 위한 useModalStore 세팅

## 🔍 관련 이슈

- Closes #25 

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 주요 변경 내용을 리스트로 정리해주세요.

`ex`

- 로그인 API 연동 (`/api/login`) 추가
- 로그인 폼에서 이메일/비밀번호 유효성 검사 로직 추가
- 로그인 성공 시 JWT 토큰을 localStorage에 저장하도록 수정
- UI: 로그인 버튼 클릭 시 로딩 스피너 추가

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- 추가로 다크테마 버튼 토글 페이지가 아닌 레이아웃으로 빼두었습니다. (#18 에 적용된 이슈)
