### PR TITLE
feat: add form label component (#33)

### DIFF
--- a/src/shared/ui/Label.tsx
+++ b/src/shared/ui/Label.tsx
@@ -1,0 +1,31 @@
+import { forwardRef, LabelHTMLAttributes, ReactNode } from 'react';
+
+import { cn } from '@/shared/lib/cn';
+
+import { TEXT_VARIANTS, type TextVariant } from './Text';
+
+type LabelTextSize = Extract<TextVariant, '14_M' | '14_B' | '16_M' | '16_B'>;
+
+interface LabelProps extends Omit<LabelHTMLAttributes<HTMLLabelElement>, 'children'> {
+  className?: string;
+  textSize?: LabelTextSize;
+  textColor?: 'gray_950' | 'white' | 'primary';
+  children: ReactNode;
+}
+
+const Label = forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, children, textSize = '14_M', textColor = 'gray_950', ...props }, ref) => {
+    return (
+      <label
+        ref={ref}
+        className={cn(TEXT_VARIANTS[textSize], `text-${textColor}`, className)}
+        {...props}
+      >
+        {children}
+      </label>
+    );
+  },
+);
+
+Label.displayName = 'Label';
+export default Label;

--- a/src/shared/ui/Text.tsx
+++ b/src/shared/ui/Text.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { cn } from '@/shared/lib/cn';
 
-const TEXT_VARIANTS = {
+export const TEXT_VARIANTS = {
   '11_M': 'text-[11px] leading-[1.3] font-[500]',
   '11_B': 'text-[11px] leading-[1.3] font-[700]',
   '12_M': 'text-[12px] leading-[1.3] font-[500]',

--- a/src/stories/Label.stories.tsx
+++ b/src/stories/Label.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import Label from '@/shared/ui/Label';
+
+const meta = {
+  title: 'Components/Label',
+  component: Label,
+  tags: ['autodocs'],
+  argTypes: {
+    className: { control: { type: 'text' } },
+    textSize: { control: { type: 'inline-radio' } },
+    textColor: { control: { type: 'inline-radio' } },
+    children: { control: { type: 'text' } },
+    htmlFor: { control: { type: 'text' } },
+  },
+  args: {
+    className: '',
+    textSize: '14_M',
+    textColor: 'gray_950',
+    children: '라벨 텍스트',
+    htmlFor: 'input-id',
+  },
+} satisfies Meta<typeof Label>;
+
+export default meta;
+
+export const Default: StoryObj<typeof Label> = {};


### PR DESCRIPTION
## 📌 PR 개요

- Label 컴포넌트 작성

## 🔍 관련 이슈

- Closes #33

## 🔧 변경 유형
- [x] ✨ feat (새 기능 추가)

## ✨ 변경 사항

### `Text.tsx`
- 정의된 `TEXT_VARIANTS`를 외부에서 활용하기 위해 `export` 추가

### `Label.tsx`
- form에서 활용 가능한 Label 컴포넌트 구현
- `textSize` : `'14_M' | '14_B' | '16_M' | '16_B'` 중 선택

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

## 🤝 기타 참고 사항

- 피그마를 보고 사이즈를 네가지로 지정했으나, 혹시 더 필요한 사이즈가 있다면 수정/추후 추가하겠습니다
