### PR TITLE
feat: add divider component (#34)

### DIFF
--- a/src/shared/ui/Divider/Divider.styles.tsx
+++ b/src/shared/ui/Divider/Divider.styles.tsx
@@ -1,0 +1,15 @@
+import { tv } from 'tailwind-variants';
+
+export const styles = tv({
+  base: 'block',
+  variants: {
+    orientation: {
+      horizontal: 'w-full',
+      vertical: 'h-full',
+    },
+    color: {
+      gray100: 'bg-gray-100',
+      gray300: 'bg-gray-300',
+    },
+  },
+});

--- a/src/shared/ui/Divider/Divider.tsx
+++ b/src/shared/ui/Divider/Divider.tsx
@@ -1,0 +1,40 @@
+import { CSSProperties, HTMLAttributes } from 'react';
+
+import { cn } from '../../lib/cn';
+
+import { styles } from './Divider.styles';
+
+interface DividerProps extends Omit<HTMLAttributes<HTMLDivElement>, 'color'> {
+  className?: string;
+  color?: 'gray100' | 'gray300';
+  width?: number;
+  orientation?: 'vertical' | 'horizontal';
+}
+
+const Divider = ({
+  className,
+  color = 'gray100',
+  width = 1,
+  orientation = 'horizontal',
+  ...props
+}: DividerProps) => {
+  const thickness = Math.max(1, Number.isFinite(width) ? Number(width) : 1);
+  const dynamicStyle: CSSProperties =
+    orientation === 'horizontal' ? { height: `${thickness}px` } : { width: `${thickness}px` };
+
+  const classes = styles({ orientation, color });
+  const mergedStyle: CSSProperties = {
+    ...dynamicStyle,
+  };
+  return (
+    <div
+      className={cn(classes, className)}
+      style={mergedStyle}
+      role="separator"
+      aria-orientation={orientation}
+      {...props}
+    />
+  );
+};
+
+export default Divider;

--- a/src/stories/Divider.stories.tsx
+++ b/src/stories/Divider.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import Divider from '@/shared/ui/Divider/Divider';
+
+const meta = {
+  title: 'Components/Divider',
+  component: Divider,
+  tags: ['autodocs'],
+  argTypes: {
+    className: { control: { type: 'text' } },
+    color: { control: { type: 'inline-radio' } },
+    width: { control: { type: 'number' } },
+    orientation: { control: { type: 'inline-radio' } },
+    id: { control: { type: 'text' } },
+  },
+  args: {
+    className: '',
+    color: 'gray100',
+    width: 1,
+    orientation: 'horizontal',
+    id: 'divider-id',
+  },
+} satisfies Meta<typeof Divider>;
+
+export default meta;
+
+export const Default: StoryObj<typeof Divider> = {};


### PR DESCRIPTION
## 📌 PR 개요

- 공용 Divider 컴포넌트를 구현합니다.

## 🔍 관련 이슈

- Closes #34

## 🔧 변경 유형
- [x] ✨ feat (새 기능 추가)

## ✨ 변경 사항

`props` | `type` | 설명
-- | -- | --
`className?` | `string` | 
`color?` | `'gray100' | 'gray300'` | 
`width?` | `number` | 선 두께를 지정(길이는 부모 요소의 너비에 따름)
`orientation?` | `'vertical' | 'horizontal'` | 가로/세로 방향 지정


## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)


## 🤝 기타 참고 사항

