### PR TITLE
feat: add main content widget (#52)

### DIFF
--- a/src/stories/MainContent.stories.tsx
+++ b/src/stories/MainContent.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import MainContent from '@/widgets/main/MainContent';
+
+const meta = {
+  title: 'Widgets/MainContent',
+  component: MainContent,
+  tags: ['autodocs'],
+  argTypes: {},
+  args: {},
+} satisfies Meta<typeof MainContent>;
+
+export default meta;
+
+export const Default: StoryObj<typeof MainContent> = {};

--- a/src/widgets/main/AllSection.tsx
+++ b/src/widgets/main/AllSection.tsx
@@ -1,0 +1,47 @@
+const AllSection = () => {
+  return (
+    <div className="flex flex-col items-center mt-5">
+      {/* header */}
+      <div className="flex justify-between mb-7.5 w-full">
+        <div className="flex gap-5">
+          <span className="border rounded-full px-2 py-1">뱃지</span>
+          <span className="border rounded-full px-2 py-1">뱃지</span>
+          <span className="border rounded-full px-2 py-1">뱃지</span>
+          <span className="border rounded-full px-2 py-1">뱃지</span>
+          <span className="border rounded-full px-2 py-1">뱃지</span>
+        </div>
+        <div>가격 ▼</div>
+      </div>
+      {/* body */}
+      <div className="w-full">
+        <div className="flex gap-6 mb-5">
+          <div className="w-78 h-91.5 rounded-3xl border" />
+          <div className="w-78 h-91.5 rounded-3xl border" />
+          <div className="w-78 h-91.5 rounded-3xl border" />
+          <div className="w-78 h-91.5 rounded-3xl border" />
+          <div className="w-78 h-91.5 rounded-3xl border" />
+        </div>
+        <div className="flex gap-6 mb-5">
+          <div className="w-78 h-91.5 rounded-3xl border" />
+          <div className="w-78 h-91.5 rounded-3xl border" />
+          <div className="w-78 h-91.5 rounded-3xl border" />
+          <div className="w-78 h-91.5 rounded-3xl border" />
+
+          <div className="w-78 h-91.5 rounded-3xl border" />
+        </div>
+        <div className="flex gap-6 mb-5">
+          <div className="w-78 h-91.5 rounded-3xl border" />
+          <div className="w-78 h-91.5 rounded-3xl border" />
+          <div className="w-78 h-91.5 rounded-3xl border" />
+          <div className="w-78 h-91.5 rounded-3xl border" />
+
+          <div className="w-78 h-91.5 rounded-3xl border" />
+        </div>
+      </div>
+      {/* pagination */}
+      <div className="border w-76 h-10"></div>
+    </div>
+  );
+};
+
+export default AllSection;

--- a/src/widgets/main/MainContent.tsx
+++ b/src/widgets/main/MainContent.tsx
@@ -1,0 +1,42 @@
+import Text from '@/shared/ui/Text';
+
+import AllSection from './AllSection';
+import PopularSection from './PopularSection';
+
+const MainContent = () => {
+  return (
+    <div className="flex flex-col justify-center max-w-330">
+      <div className="mb-11">
+        {/* <MainHero /> */}
+        <div className="border w-full h-125 rounded-3xl" />
+      </div>
+      {/* 검색*/}
+      <section className="flex flex-col items-center gap-9 mb-7 py-8 px-10">
+        <Text.B16 as="h2" className="md:text-[32px] md:font-bold">
+          무엇을 체험하고 싶으신가요?
+        </Text.B16>
+        {/* <SearchInput /> */}
+        <div className="w-full border h-17.5" />
+      </section>
+      <div>
+        {/* 인기 체험 */}
+        <section className="mb-15">
+          <Text.B18 as="h2" className="md:text-[32px] md:font-bold">
+            🔥 인기 체험
+          </Text.B18>{' '}
+          {/* 왜 classname 적용 안되지*/}
+          <PopularSection />
+        </section>
+        {/* 모든 체험 */}
+        <section>
+          <Text.B18 as="h2" className="md:text-[32px] md:font-bold">
+            🛼 모든 체험
+          </Text.B18>
+          <AllSection />
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default MainContent;

--- a/src/widgets/main/PopularSection.tsx
+++ b/src/widgets/main/PopularSection.tsx
@@ -1,0 +1,17 @@
+const PopularSection = () => {
+  return (
+    <div className="relative mt-5">
+      {/* 아래 내용들을 지우고 실제 요소로 작성 */}
+      <div className="rounded-full w-13.5 h-13.5 border absolute -left-6.5 top-1/2 -translate-y-1/2" />
+      <div className="flex gap-6">
+        <div className="w-78 h-91.5 rounded-3xl border" />
+        <div className="w-78 h-91.5 rounded-3xl border" />
+        <div className="w-78 h-91.5 rounded-3xl border" />
+        <div className="w-78 h-91.5 rounded-3xl border" />
+      </div>
+      <div className="rounded-full w-13.5 h-13.5 border absolute -right-6.5 top-1/2 -translate-y-1/2" />
+    </div>
+  );
+};
+
+export default PopularSection;


### PR DESCRIPTION
## 📌 PR 개요

- `MainContent` 컴포넌트 추가

## 🔍 관련 이슈

- Closes #52

## 🔧 변경 유형
- [x] ✨ feat (새 기능 추가)

## ✨ 변경 사항

- `MainContent`에 들어갈 요소 섹션 구분
- 확인을 위해서 간단하게 `div`로 스켈레톤 작성
- 반응형 디자인 (텍스트)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)


## 🤝 기타 참고 사항

- 
