### PR TITLE
feat: 회원가입 폼 유효성 검증 구현 (#134)

### DIFF
--- a/src/features/signup/model/useSignupForm.ts
+++ b/src/features/signup/model/useSignupForm.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+
+import { SignupFormValues, SignupSchema } from '@/shared/schema/auth';
+
+export const useSignupForm = () => {
+  const form = useForm<SignupFormValues>({
+    resolver: zodResolver(SignupSchema),
+    mode: 'onChange',
+    defaultValues: { email: '', nickname: '', password: '', passwordConfirm: '' },
+  });
+
+  return form;
+};

--- a/src/features/signup/ui/SignupForm.tsx
+++ b/src/features/signup/ui/SignupForm.tsx
@@ -4,23 +4,17 @@
 
 import Image from 'next/image';
 import { useState } from 'react';
-import { useForm } from 'react-hook-form';
 
 import KakaoIcon from '@/shared/assets/images/icons/icon_kakao.png';
 import EyeIcon from '@/shared/assets/images/icons/visibility_off.svg';
-import { Email, Password } from '@/shared/schema/auth';
+import { SignupFormValues } from '@/shared/schema/auth';
 import Button from '@/shared/ui/Button/Button';
 import Divider from '@/shared/ui/Divider/Divider';
 import Input from '@/shared/ui/Input/Input';
 import Label from '@/shared/ui/Label';
 import Text from '@/shared/ui/Text';
 
-type SignupFormValues = {
-  email: string;
-  nickname: string;
-  password: string;
-  passwordConfirm: string;
-};
+import { useSignupForm } from '../model/useSignupForm';
 
 export const SignupForm = () => {
   const [showPassword, setShowPassword] = useState(false);
@@ -29,33 +23,24 @@ export const SignupForm = () => {
   const {
     register,
     handleSubmit,
-    getValues,
     formState: { errors, isValid },
-  } = useForm<SignupFormValues>({
-    mode: 'onChange',
-    reValidateMode: 'onChange',
-    defaultValues: { email: '', nickname: '', password: '', passwordConfirm: '' },
-  });
+  } = useSignupForm();
 
-  const onSubmit = (data: SignupFormValues) => {
+  const handleSignup = (data: SignupFormValues) => {
     // TODO: api 연결
     console.warn('가입 데이터:', data);
   };
 
   return (
     <div className="flex flex-col items-center w-full max-w-160">
-      <form onSubmit={handleSubmit(onSubmit)} className="w-full space-y-5">
+      <form onSubmit={handleSubmit(handleSignup)} className="w-full space-y-5">
         {/* 이메일 */}
         <div className="flex flex-col gap-3">
           <Label htmlFor="signup-email" textSize="16_M">
             이메일
           </Label>
           <Input
-            {...register('email', {
-              required: '이메일을 입력해 주세요.',
-              validate: (value) =>
-                Email.safeParse(value).success || '올바른 이메일 형식을 입력해 주세요.',
-            })}
+            {...register('email')}
             id="signup-email"
             type="email"
             placeholder="이메일을 입력해주세요"
@@ -71,11 +56,11 @@ export const SignupForm = () => {
             닉네임
           </Label>
           <Input
-            {...register('nickname', {
-              required: '닉네임을 입력해 주세요.',
-            })}
+            {...register('nickname')}
             id="signup-nickname"
             placeholder="닉네임을 입력해주세요"
+            error={!!errors.nickname}
+            errorMsg={errors.nickname?.message}
           />
         </div>
 
@@ -86,13 +71,7 @@ export const SignupForm = () => {
           </Label>
           <div className="relative">
             <Input
-              {...register('password', {
-                required: '비밀번호를 입력해 주세요.',
-                validate: (value) => {
-                  if (!Password.safeParse(value).success) return '8자 이상 입력해 주세요.';
-                  return true;
-                },
-              })}
+              {...register('password')}
               id="signup-password"
               type={showPassword ? 'text' : 'password'}
               placeholder="8자 이상 입력해 주세요"
@@ -118,11 +97,7 @@ export const SignupForm = () => {
           </Label>
           <div className="relative">
             <Input
-              {...register('passwordConfirm', {
-                required: '비밀번호 확인을 입력해 주세요.',
-                validate: (value) =>
-                  value === getValues('password') || '비밀번호가 일치하지 않습니다.',
-              })}
+              {...register('passwordConfirm')}
               id="signup-password-confirm"
               type={showConfirm ? 'text' : 'password'}
               placeholder="비밀번호를 한 번 더 입력해 주세요"

--- a/src/shared/schema/auth.ts
+++ b/src/shared/schema/auth.ts
@@ -1,19 +1,26 @@
 import { z } from 'zod';
 
 import { OauthProviderEnumSchema } from '@/shared/schema/enums';
-import { Url, NonEmptyString } from '@/shared/schema/primitives';
+import { Url } from '@/shared/schema/primitives';
 
 export const Email = z
   .string()
   .min(1, '이메일을 입력해 주세요.')
   .email('이메일 형식이 올바르지 않습니다.');
 
+export const Nickname = z
+  .string()
+  .trim() // 공백 방지
+  .min(1, '닉네임을 입력해 주세요.')
+  .max(20, '닉네임은 20자 이내로 입력해주세요.');
+
 export const Password = z
   .string()
+  .trim()
   .min(1, '비밀번호를 입력해 주세요.')
   .min(8, '비밀번호는 8자 이상이어야 합니다.');
 
-export const Nickname = NonEmptyString;
+export const PasswordConfirm = z.string().min(1, '비밀번호 확인을 입력해 주세요.');
 
 export const LoginSchema = z.object({
   email: Email,
@@ -22,6 +29,21 @@ export const LoginSchema = z.object({
 
 // 객체를 “어떻게 보겠다”는 타입 설명서
 export type LoginFormValues = z.infer<typeof LoginSchema>;
+
+// ===== SIGN UP =====
+export const SignupSchema = z
+  .object({
+    nickname: Nickname,
+    email: Email,
+    password: Password,
+    passwordConfirm: PasswordConfirm,
+  })
+  .refine((data) => data.password === data.passwordConfirm, {
+    path: ['passwordConfirm'],
+    message: '비밀번호가 일치하지 않습니다.',
+  });
+
+export type SignupFormValues = z.infer<typeof SignupSchema>;
 
 export const OauthToken = z.union([
   // JWT


### PR DESCRIPTION
## 📌 PR 개요

- zod를 사용하여 회원가입 폼 유효성 검증 구현

## 🔍 관련 이슈

- Closes #134

## 🔧 변경 유형

- [x] ✨ feat (새 기능 추가)

## ✨ 변경 사항
- `useSignupForm.tsx`
    - 정의한 스키마로 resolver 적용한 `useSignupForm` 작성
- `SignupForm.tsx`
    - `useSignupForm`을 사용하여 기존 form 관련 설정을 덮어씀
    - nickname에 에러 상태 표시 
- `shared/schema/auth.ts`
    - `Nickname` 스키마 수정 (1글자 이상, 20자 이내)
    - `PasswordConfirm` 스키마 추가
    - `SignupSchema` 객체 스키마 추가
        - `refine`을 사용하여 비밀번호 일치 여부 확인

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)
<img width="1056" height="774" alt="image" src="https://github.com/user-attachments/assets/79b28621-19aa-42ad-9777-f3380f84c1b9" />


## 🤝 기타 참고 사항

