### PR TITLE
feat: 로그아웃 처리 (#157)

### DIFF
--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  const res = new NextResponse(null, { status: 204 });
+
+  res.cookies.delete('accessToken');
+  res.cookies.delete('refreshToken');
+
+  return res;
+}

--- a/src/features/auth/api/logout.ts
+++ b/src/features/auth/api/logout.ts
@@ -1,0 +1,8 @@
+import { clientApi } from '@/shared/api/client';
+
+export const logoutApi = async (): Promise<void> => {
+  await clientApi.requestVoid({
+    method: 'POST',
+    path: '/auth/logout',
+  });
+};


### PR DESCRIPTION
## 📌 PR 개요

-  로그아웃 api 구현

## 🔍 관련 이슈

- Closes #157
  (ex. Closes #12)

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- Logout 전용 BFF 앱 라우트 핸들러 구현
- Logout Api 구현

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- `/login` 이동은 API 책임이 아니라 클라이언트 책임으로 분리했습니다.
- `/api/auth/logout`은 HttpOnly 쿠키 제거 및 상태코드 반환만 담당하며, 라우트 이동은 호출부에서 처리하도록 구성했습니다.
- 현재 `/api/auth/logout`은 로그인 여부를 검사하지 않고 항상 동일하게 작동합니다.
- 요청 쿠키 유무와 관계없이 accessToken/refreshToken HttpOnly 쿠키를 삭제하도록 set-cookie 헤더를 내려주며, 204(no content)로 응답합니다(이미 로그아웃된 상태로 호출해도 동일하게 동작)
- zustand 상태 초기화는 현재 전역 상태, 로그인 종속 상태를 몰라 확인되는 시점에 reset 액션 호출을 묶는 useLogout 훅으로 일괄 정리하겠습니다
