### PR TITLE
feat: add calendar ui (#230)

### DIFF
--- a/src/app/(dev)/calendar/page.tsx
+++ b/src/app/(dev)/calendar/page.tsx
@@ -1,0 +1,9 @@
+import CalendarComp from '@/shared/ui/Calendar/CalendarComp';
+
+export default function page() {
+  return (
+    <div>
+      <CalendarComp activityId={1} />
+    </div>
+  );
+}

--- a/src/shared/ui/Calendar/CalendarComp.css
+++ b/src/shared/ui/Calendar/CalendarComp.css
@@ -1,0 +1,242 @@
+/* ===== HEADER ===== */
+.calendar-comp-calendar .fc-toolbar {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.calendar-comp-calendar .fc-toolbar-title {
+  font-size: 16px;
+  line-height: 1.3;
+  font-weight: 500;
+  margin: 0 16px;
+}
+/* 헤더 전체 하단 여백 축소 */
+.fc.calendar-comp-calendar .fc-toolbar.fc-header-toolbar {
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+}
+
+.calendar-comp-calendar .fc-toolbar-chunk {
+  display: flex;
+  align-items: center;
+  width: fit-content;
+}
+
+/* 헤더 버튼 */
+.calendar-comp-calendar .fc-prev-button,
+.calendar-comp-calendar .fc-next-button {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border-radius: 9999px;
+  background-color: transparent;
+  color: black;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: none;
+}
+.calendar-comp-calendar .fc-button .fc-icon {
+  font-size: 12px;
+  line-height: 1;
+}
+.calendar-comp-calendar .fc-icon::before {
+  line-height: 1;
+}
+
+/* ===== DAYS ===== */
+.calendar-comp-calendar .fc-col-header-cell-cushion {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 500;
+  color: #1f2937;
+  padding: 8px 0;
+}
+
+.calendar-comp-calendar .fc-day-sun .fc-col-header-cell-cushion {
+  color: #ef4444;
+}
+
+.calendar-comp-calendar .fc-day-sat .fc-col-header-cell-cushion {
+  color: #3b82f6;
+}
+
+/* ===== DATE DEFAULT ===== */
+.calendar-comp-calendar .fc-scrollgrid-sync-table {
+  flex: 1 0 0;
+}
+
+.calendar-comp-calendar .fc-daygrid-day-frame {
+  position: relative;
+  width: 100%;
+  height: 124px;
+  padding: 4px;
+  align-items: flex-start;
+  justify-content: flex-start;
+  cursor: default;
+  border-radius: 8px;
+  transition: background-color 0.2s;
+}
+@media (max-width: 768px) {
+  .calendar-comp-calendar .fc-daygrid-day-frame {
+    height: 104px;
+  }
+}
+
+.calendar-comp-calendar .fc-day-today .fc-daygrid-day-frame {
+  background-color: #dbeafe;
+}
+
+.calendar-comp-calendar .fc-daygrid-day.selectable-date .fc-daygrid-day-frame:hover {
+  background-color: #eff6ff;
+  cursor: pointer;
+}
+
+.calendar-comp-calendar .fc-daygrid-day.fc-day-selected .fc-daygrid-day-frame {
+  background-color: #60a5fa;
+}
+
+.calendar-comp-calendar .fc-daygrid-day.fc-day-selected .fc-daygrid-day-frame:hover {
+  background-color: #60a5fa;
+}
+
+/* ===== DATE NUMBER ===== */
+.calendar-comp-calendar .fc-daygrid-day-top {
+  display: flex;
+  justify-content: center;
+  position: relative;
+}
+
+.calendar-comp-calendar .fc-daygrid-day .fc-daygrid-day-number {
+  font-size: 14px;
+  padding-bottom: 0;
+  font-weight: 500;
+  color: #1f2937;
+}
+@media (max-width: 768px) {
+  .calendar-comp-calendar .fc-daygrid-day .fc-daygrid-day-number {
+    font-size: 12px;
+  }
+}
+
+/* ===== EVENTS ===== */
+.calendar-comp-calendar .fc-daygrid-day-events {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.calendar-comp-calendar .fc-daygrid-event {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+}
+.calendar-comp-calendar .fc-event-main {
+  padding: 0;
+  margin: 0;
+}
+.calendar-comp-calendar .fc-event-main-frame {
+  padding: 0;
+  margin: 0;
+}
+.calendar-comp-calendar .fc-event-title-container {
+  display: flex;
+  padding: 0;
+  margin: 0;
+}
+.calendar-comp-calendar .fc-event-title {
+  font-weight: 500;
+  font-size: 14px;
+  padding: 0;
+}
+
+@media (max-width: 768px) {
+  .calendar-comp-calendar .fc-event-title {
+    font-size: 11px;
+  }
+}
+
+/* 완료 */
+.calendar-comp-calendar .event-completed {
+  background-color: #edeef2;
+}
+.calendar-comp-calendar .event-completed .fc-event-title-container {
+  color: #84858c;
+}
+
+/* 예약 */
+.calendar-comp-calendar .event-pending {
+  background-color: #e5f3ff;
+}
+.calendar-comp-calendar .event-pending .fc-event-title-container {
+  color: #3d9ef2;
+}
+
+/* 승인 */
+.calendar-comp-calendar .event-confirmed {
+  background-color: #fff8dd;
+}
+.calendar-comp-calendar .event-confirmed .fc-event-title-container {
+  color: #ffb051;
+}
+
+/* ===== NOTIFICATION DOT ===== */
+.notification-dot {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 8px;
+  height: 8px;
+  background-color: #ef4444;
+  border-radius: 50%;
+  z-index: 10;
+}
+
+/* data 속성 기반으로 CSS가 빨간 점 렌더링 */
+.fc-daygrid-day[data-has-new-notification='true'] .fc-daygrid-day-frame::after {
+  content: '';
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 8px;
+  height: 8px;
+  background-color: #ef4444;
+  border-radius: 50%;
+  z-index: 10;
+}
+
+/* ===== REMOVE BORDER ===== */
+.calendar-comp-calendar .fc-scrollgrid,
+.calendar-comp-calendar .fc-scrollgrid td,
+.calendar-comp-calendar .fc-scrollgrid th,
+.calendar-comp-calendar .fc-col-header-cell {
+  border: none;
+}
+
+/* ===== REMOVE DEFAULT STYLES ===== */
+/* 기본 스타일의 경우 important를 넣지 않으면 사라지지 않아 !important가 추가되었습니다. */
+.calendar-comp-calendar .fc-highlight {
+  background-color: transparent !important;
+}
+
+.calendar-comp-calendar .fc-day-today {
+  background-color: transparent !important;
+}
+
+.calendar-comp-calendar .fc-button:hover,
+.calendar-comp-calendar .fc-button:focus,
+.calendar-comp-calendar .fc-button:active,
+.calendar-comp-calendar .fc-button:focus-visible {
+  background-color: var(--color-blue-50) !important;
+  color: black !important;
+  border: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+}

--- a/src/shared/ui/Calendar/CalendarComp.tsx
+++ b/src/shared/ui/Calendar/CalendarComp.tsx
@@ -1,0 +1,296 @@
+'use client';
+import { Calendar, EventInput } from '@fullcalendar/core';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import { useEffect, useRef, useState } from 'react';
+
+import { useModalStore } from '@/shared/stores/useModalStore';
+import './CalendarComp.css';
+
+// TODO: 모달 컴포넌트로 분리해서 제작
+const examplemodal = (date: string, reservations: Reservations) => {
+  const formattedDate = new Date(date).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+  return (
+    <div className="flex flex-col gap-4">
+      <span>{formattedDate}</span>
+      <span>완료: {reservations.completed}</span>
+      <span>승인: {reservations.confirmed}</span>
+      <span>예약: {reservations.pending}</span>
+    </div>
+  );
+};
+
+type Reservations = {
+  completed: number;
+  confirmed: number;
+  pending: number;
+};
+
+interface ReservationData {
+  date: string;
+  reservations: Reservations;
+  activityId?: number;
+}
+
+interface CalendarCompProps {
+  onDateSelect?: (date: string) => void;
+  activityId: number;
+}
+
+const CalendarComp = ({ onDateSelect, activityId }: CalendarCompProps) => {
+  const calendarRef = useRef<HTMLDivElement>(null);
+  const calendarInstanceRef = useRef<Calendar>(null);
+
+  const [reservationData, setReservationData] = useState<ReservationData[]>([]);
+  const [viewedDates, setViewedDates] = useState<Set<string>>(new Set());
+  const [currentYear, setCurrentYear] = useState(new Date().getFullYear());
+  const [currentMonth, setCurrentMonth] = useState(new Date().getMonth() + 1);
+
+  const { openBaseModal } = useModalStore();
+
+  // 연/월 바뀔 때 예약 데이터 가져옴
+  useEffect(() => {
+    const year = currentYear.toString();
+    const month = String(currentMonth).padStart(2, '0');
+    fetchReservations(year, month);
+  }, [currentYear, currentMonth, activityId]);
+
+  // 로컬 스토리지에서 예약 내역 조회 상태 로드
+  useEffect(() => {
+    const stored = sessionStorage.getItem('viewedReservations');
+    if (stored) {
+      setViewedDates(new Set(JSON.parse(stored)));
+    }
+  }, []);
+
+  // 조회 상태 저장
+  const markAsViewed = (date: string) => {
+    setViewedDates((prev) => {
+      const newViewed = new Set(prev);
+      newViewed.add(date);
+      sessionStorage.setItem('viewedReservations', JSON.stringify([...newViewed]));
+      return newViewed;
+    });
+  };
+
+  // TODO: API 데이터 조회
+  const fetchReservations = async (_year: string, _month: string) => {
+    try {
+      // 실제 API 호출 예시
+      // const response = await fetch(
+      //   `/${teamId}/my-activities/${activityId}/reservation-dashboard?year=${year}&month=${month}`
+      // );
+      // const data = await response.json();
+
+      // 데모 데이터
+      const mockData: ReservationData[] = [
+        {
+          date: '2026-01-09',
+          reservations: { completed: 2, confirmed: 1, pending: 0 },
+        },
+        {
+          date: '2026-01-15',
+          reservations: { completed: 0, confirmed: 3, pending: 1 },
+        },
+        {
+          date: '2026-01-20',
+          reservations: { completed: 1, confirmed: 0, pending: 2 },
+        },
+        {
+          date: '2026-01-21',
+          reservations: { completed: 5, confirmed: 2, pending: 1 },
+        },
+        {
+          date: '2026-01-24',
+          reservations: { completed: 5, confirmed: 2, pending: 1 },
+        },
+        {
+          date: '2026-02-06',
+          reservations: { completed: 0, confirmed: 0, pending: 3 },
+        },
+      ];
+
+      setReservationData(mockData);
+    } catch (error) {
+      console.error('예약 데이터 조회 실패:', error);
+    }
+  };
+
+  const createEvents = (): EventInput[] => {
+    return reservationData.flatMap((item) => {
+      const { date, reservations } = item;
+      const eventTypes = [
+        {
+          status: 'completed',
+          title: '완료',
+          count: reservations.completed,
+          className: 'event-completed',
+        },
+        {
+          status: 'confirmed',
+          title: '승인',
+          count: reservations.confirmed,
+          className: 'event-confirmed',
+        },
+        {
+          status: 'pending',
+          title: '예약',
+          count: reservations.pending,
+          className: 'event-pending',
+        },
+      ] as const;
+
+      return eventTypes
+        .filter(({ count }) => count > 0)
+        .map(({ status, title, count, className }) => ({
+          start: date,
+          allDay: true,
+          title: `${title} ${count}`,
+          classNames: [className],
+          extendedProps: {
+            type: status,
+            date,
+            reservations,
+          },
+        }));
+    });
+  };
+
+  // 날짜별 예약 존재 여부 확인
+  const hasReservations = (dateStr: string) => {
+    return reservationData.some((item) => item.date === dateStr);
+  };
+
+  // viewedDates 변경 시 data 속성 업데이트
+  useEffect(() => {
+    if (!calendarRef.current) return;
+
+    const allDays = calendarRef.current.querySelectorAll('.fc-daygrid-day');
+    allDays.forEach((dayEl) => {
+      const dateStr = dayEl.getAttribute('data-date');
+      if (dateStr && hasReservations(dateStr)) {
+        const isNew = !viewedDates.has(dateStr);
+        dayEl.setAttribute('data-has-new-notification', isNew.toString());
+      }
+    });
+  }, [viewedDates, reservationData]);
+
+  // 캘린더 업데이트
+  useEffect(() => {
+    if (!calendarRef.current) return;
+
+    // 달력 한 번만 생성
+    if (!calendarInstanceRef.current) {
+      calendarInstanceRef.current = new Calendar(calendarRef.current, {
+        plugins: [dayGridPlugin, interactionPlugin],
+        events: createEvents(),
+        initialView: 'dayGridMonth',
+        headerToolbar: {
+          start: 'prev',
+          center: 'title',
+          end: 'next',
+        },
+        titleFormat: { year: 'numeric', month: 'long' },
+        dayHeaderFormat: { weekday: 'narrow' }, // 요일 한글자로 표시
+        selectable: true,
+        selectMirror: true,
+        selectOverlap: true,
+        unselectAuto: false,
+        dayMaxEventRows: false,
+        height: 'auto',
+
+        // 달력 그리기
+        datesSet: (info) => {
+          const current = info.view.currentStart;
+          setCurrentYear(current.getFullYear());
+          setCurrentMonth(current.getMonth() + 1);
+        },
+
+        // 모달 열기
+        eventClick: (info) => {
+          info.jsEvent.preventDefault();
+          info.jsEvent.stopPropagation();
+          const { date, reservations } = info.event.extendedProps;
+
+          openBaseModal({
+            content: examplemodal(date, reservations),
+            showCloseButton: true,
+          });
+
+          markAsViewed(date);
+        },
+
+        // 선택 처리
+        select: (info) => {
+          // event 날짜만 선택 가능
+          if (!hasReservations(info.startStr) && calendarInstanceRef.current) {
+            calendarInstanceRef.current.unselect();
+            return;
+          }
+
+          // 선택 상태 업데이트
+          const allDays = calendarRef.current?.querySelectorAll('.fc-daygrid-day');
+          allDays?.forEach((day) => day.classList.remove('fc-day-selected'));
+
+          const selectedDay = calendarRef.current?.querySelector(`[data-date="${info.startStr}"]`);
+          selectedDay?.classList.add('fc-day-selected');
+
+          // 상태를 업데이트하여 알림 점을 영구적으로 제거
+          markAsViewed(info.startStr);
+
+          if (onDateSelect) {
+            onDateSelect(info.startStr);
+          }
+        },
+
+        // 클래스 처리
+        dayCellClassNames: (arg) => {
+          const classes = [];
+          const year = arg.date.getFullYear();
+          const month = String(arg.date.getMonth() + 1).padStart(2, '0');
+          const day = String(arg.date.getDate()).padStart(2, '0');
+          const dateStr = `${year}-${month}-${day}`;
+
+          if (hasReservations(dateStr)) {
+            classes.push('selectable-date');
+          } else {
+            classes.push('not-selectable-date');
+          }
+
+          return classes;
+        },
+
+        // data 속성으로 새 알림 표시 (CSS로 렌더링)
+        dayCellDidMount: (arg) => {
+          const year = arg.date.getFullYear();
+          const month = String(arg.date.getMonth() + 1).padStart(2, '0');
+          const day = String(arg.date.getDate()).padStart(2, '0');
+          const dateStr = `${year}-${month}-${day}`;
+
+          if (hasReservations(dateStr)) {
+            const isNew = !viewedDates.has(dateStr);
+            arg.el.setAttribute('data-has-new-notification', isNew.toString());
+          }
+        },
+      });
+
+      calendarInstanceRef.current.render();
+    }
+
+    // 예약 데이터가 바뀌거나 연/월 바뀌면 이벤트 갱신
+    calendarInstanceRef.current.setOption('events', createEvents());
+  }, [reservationData, currentYear, currentMonth]);
+
+  return (
+    <div
+      className="calendar-comp-calendar lg:w-160 lg:h-204 md:w-120 md:h-204 w-full h-fit border"
+      ref={calendarRef}
+    />
+  );
+};
+
+export default CalendarComp;


### PR DESCRIPTION
## 📌 PR 개요

- fullcalendar를 사용하여 캘린더 ui 구현

## 🔍 관련 이슈

- Closes #230

## 🔧 변경 유형
- [x] ✨ feat (새 기능 추가)

## ✨ 변경 사항

- 캘린더 UI 추가
### `CalendarComp.tsx`
- Figma같이 Popover 컴포넌트 사용시, Popover 컴포넌트 수정사항이 많아져 우선 달력 클릭 시 모달로 띄우도록 구현
- 피그마 상의 빨간 점의 상태를 로컬에 저장하여 클릭 시 지워지는 모습으로 구현 (백에서의 신규 상태 관리가 없음)
- 반응형 구현

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- 이전 pr이 리베이스중 꼬여서 다시 올렸습니다! 코멘트로 gemini랑 유진님이 중요하게 리뷰 달아주신 게 좀 있어서 확인해주시면 좋을 것 같습니다.[기존 pr (리뷰 확인)](https://github.com/FE19-Team3/global_nomad/pull/217)
    - 새로운 알림(빨간점) UI는 어느정도 해결했습니다.
- 현재 date 자체의 클릭이벤트가 안먹고 이벤트에 대해서만 클릭이벤트, 호버가 먹고 있는데 다음 작업에 필요할 것 같아서 일단 리팩토링으로 남겨두고 올리겠습니다

