### PR TITLE
feat: 전체 체험 리스트 조회 (#188)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,9 +6,16 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'images.unsplash.com',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
+        pathname: '/**',
       },
     ],
   },
+
   async redirects() {
     return [
       {

--- a/src/app/(public)/main/page.tsx
+++ b/src/app/(public)/main/page.tsx
@@ -1,7 +1,19 @@
+import { ActivityListResponseSchema } from '@/features/activity/activity-list/schema/activity-list.schema';
+import { serverApi } from '@/shared/api/server';
 import MainContent from '@/widgets/main/MainContent';
 
-const MainPage = () => {
-  return <MainContent />;
+const MainPage = async () => {
+  const initialData = await serverApi.get({
+    path: '/activities',
+    query: {
+      method: 'offset',
+      page: 1,
+      size: 20,
+    },
+    schema: ActivityListResponseSchema,
+  });
+
+  return <MainContent initialData={initialData.data} />;
 };
 
 export default MainPage;

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest } from 'next/server';
 
+import {
+  ActivityQuerySchema,
+  ActivityListResponseSchema,
+} from '@/features/activity/activity-list/schema/activity-list.schema';
 import { respondError, toApiError } from '@/shared/api';
 import { serverApi } from '@/shared/api/server';
 import {
@@ -26,6 +30,39 @@ export async function POST(req: NextRequest) {
     });
 
     return Response.json(response.data, { status: 201 });
+  } catch (e) {
+    return respondError(toApiError(e));
+  }
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+
+    // query parameters를 객체로 변환
+    const getOptionalParam = (value: string | null) =>
+      value && value.trim() !== '' ? value : undefined;
+
+    const queryParams = {
+      method: searchParams.get('method') ?? 'cursor',
+      cursorId: searchParams.get('cursorId') ? Number(searchParams.get('cursorId')) : undefined,
+      category: getOptionalParam(searchParams.get('category')),
+      keyword: getOptionalParam(searchParams.get('keyword')),
+      sort: getOptionalParam(searchParams.get('sort')),
+      page: searchParams.get('page') ? Number(searchParams.get('page')) : 1,
+      size: searchParams.get('size') ? Number(searchParams.get('size')) : 20,
+    };
+
+    // 쿼리 파라미터 유효성 검사
+    const parsed = ActivityQuerySchema.parse(queryParams);
+
+    const response = await serverApi.get({
+      path: '/activities',
+      query: parsed,
+      schema: ActivityListResponseSchema,
+    });
+
+    return Response.json(response.data, { status: 200 });
   } catch (e) {
     return respondError(toApiError(e));
   }

--- a/src/features/activity/activity-list/lib/mapToActivityCardItem.ts
+++ b/src/features/activity/activity-list/lib/mapToActivityCardItem.ts
@@ -1,0 +1,22 @@
+import type { ActivityCard } from '../model/activity-card.types';
+
+export const mapToActivityCardItem = (activity: {
+  id: number;
+  title: string;
+  category: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
+  rating: number;
+  reviewCount: number;
+}): ActivityCard => ({
+  id: activity.id,
+  title: activity.title,
+  rating: activity.rating,
+  reviewCount: activity.reviewCount,
+  price: activity.price,
+  imageUrl: activity.bannerImageUrl,
+  category: activity.category,
+  address: activity.address,
+  bannerImageUrl: activity.bannerImageUrl,
+});

--- a/src/features/activity/activity-list/model/activity-card.types.ts
+++ b/src/features/activity/activity-list/model/activity-card.types.ts
@@ -1,0 +1,11 @@
+export type ActivityCard = {
+  id: number;
+  title: string;
+  category: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
+  rating: number;
+  reviewCount: number;
+  imageUrl: string;
+};

--- a/src/features/activity/activity-list/schema/activity-list.schema.ts
+++ b/src/features/activity/activity-list/schema/activity-list.schema.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+const ActivitySchema = z.object({
+  id: z.number(),
+  userId: z.number(),
+  title: z.string(),
+  description: z.string(),
+  category: z.string(),
+  price: z.number(),
+  address: z.string(),
+  bannerImageUrl: z.string(),
+  rating: z.number(),
+  reviewCount: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const ActivityQuerySchema = z.object({
+  method: z.enum(['offset', 'cursor']),
+  cursorId: z.number().optional(),
+  category: z.enum(['문화 · 예술', '식음료', '스포츠', '투어', '관광', '웰빙']).optional(),
+  keyword: z.string().optional(),
+  sort: z.enum(['most_reviewed', 'price_asc', 'price_desc', 'latest']).optional(),
+  page: z.number().default(1),
+  size: z.number().default(20),
+});
+
+export const ActivityListResponseSchema = z.object({
+  cursorId: z.number().nullable().optional(),
+  totalCount: z.number(),
+  activities: z.array(ActivitySchema),
+});
+
+export type ActivityQuery = z.infer<typeof ActivityQuerySchema>;
+export type ActivityListResponse = z.infer<typeof ActivityListResponseSchema>;

--- a/src/features/activity/hooks/useActivityCursorList.ts
+++ b/src/features/activity/hooks/useActivityCursorList.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { clientApi } from '@/shared/api/client';
+import { ActivityCategory, ActivitySort } from '@/shared/constants/activity';
+
+import { mapToActivityCardItem } from '../activity-list/lib/mapToActivityCardItem';
+import {
+  ActivityListResponse,
+  ActivityListResponseSchema,
+} from '../activity-list/schema/activity-list.schema';
+
+interface Params {
+  category?: ActivityCategory;
+  cursorId?: number;
+  enabled?: boolean;
+  keyword?: string;
+  size?: number;
+  sort?: ActivitySort;
+  initialData?: ActivityListResponse;
+}
+
+export const useActivityCursorList = ({
+  category,
+  cursorId,
+  enabled = true,
+  keyword,
+  size = 20,
+  sort = 'latest',
+  initialData,
+}: Params) => {
+  const queryParamsForApi: Record<string, string | number> = {
+    method: 'cursor',
+    size,
+    ...(category && { category }),
+    ...(keyword && { keyword }),
+    ...(sort && { sort }),
+    ...(cursorId !== undefined && { cursorId }),
+  };
+
+  const query = useQuery({
+    queryKey: ['activities-cursor', category, cursorId, keyword, sort],
+    queryFn: async () => {
+      const res = await clientApi.get({
+        path: '/activities',
+        query: queryParamsForApi,
+        schema: ActivityListResponseSchema,
+      });
+      return res.data;
+    },
+    enabled: enabled && !initialData,
+    initialData,
+    staleTime: 5 * 60 * 1000, // 5분
+  });
+
+  return {
+    activities: query.data?.activities.map(mapToActivityCardItem) ?? [],
+    cursorId: query.data?.cursorId,
+    totalCount: query.data?.totalCount ?? 0,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+  };
+};
+
+export type UseActivityCursorListReturn = ReturnType<typeof useActivityCursorList>;

--- a/src/features/activity/hooks/useActivityOffsetList.ts
+++ b/src/features/activity/hooks/useActivityOffsetList.ts
@@ -1,0 +1,67 @@
+// activity/hooks/useActivityOffsetList.ts
+'use client';
+import { useQuery } from '@tanstack/react-query';
+
+import { clientApi } from '@/shared/api/client';
+import { ActivityCategory, ActivitySort } from '@/shared/constants/activity';
+
+import { mapToActivityCardItem } from '../activity-list/lib/mapToActivityCardItem';
+import {
+  ActivityListResponse,
+  ActivityListResponseSchema,
+  type ActivityQuery,
+} from '../activity-list/schema/activity-list.schema';
+
+interface Params {
+  category?: ActivityCategory;
+  enabled?: boolean;
+  keyword?: string;
+  page?: number;
+  size?: number;
+  sort?: ActivitySort;
+  initialData?: ActivityListResponse;
+}
+
+export const useActivityOffsetList = ({
+  category,
+  enabled = true,
+  keyword,
+  page = 1,
+  size = 20,
+  sort = 'latest',
+  initialData,
+}: Params) => {
+  const queryParams: ActivityQuery = {
+    method: 'offset',
+    page,
+    size,
+    ...(category && { category }),
+    ...(keyword && { keyword }),
+    ...(sort && { sort }),
+  };
+
+  const query = useQuery({
+    queryKey: ['activities-offset', page, category, keyword, sort],
+    queryFn: async () => {
+      const res = await clientApi.get({
+        path: '/activities',
+        query: queryParams,
+        schema: ActivityListResponseSchema,
+      });
+      return res.data;
+    },
+    enabled,
+    initialData,
+    staleTime: 5 * 60 * 1000, // 5분
+  });
+
+  return {
+    activities: query.data?.activities.map(mapToActivityCardItem) ?? [],
+    totalCount: query.data?.totalCount ?? 0,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+  };
+};
+
+export type UseActivityOffsetListReturn = ReturnType<typeof useActivityOffsetList>;

--- a/src/shared/constants/activity.ts
+++ b/src/shared/constants/activity.ts
@@ -8,3 +8,7 @@ export const ActivityCategoryValues = [
 ] as const;
 
 export type ActivityCategory = (typeof ActivityCategoryValues)[number];
+
+export const ActivitySortValues = ['most_reviewed', 'price_asc', 'price_desc', 'latest'] as const;
+
+export type ActivitySort = (typeof ActivitySortValues)[number];

--- a/src/shared/ui/Pagination/model/types.ts
+++ b/src/shared/ui/Pagination/model/types.ts
@@ -10,4 +10,5 @@ export interface PaginationProps {
   pageType: PaginationContext;
   totalCount: number;
   onPageChange: (page: number, pageSize: number) => void;
+  pageSize?: number; // 반응형 pageSize 전달
 }

--- a/src/shared/ui/Pagination/ui/Pagination.tsx
+++ b/src/shared/ui/Pagination/ui/Pagination.tsx
@@ -12,8 +12,9 @@ export const Pagination = ({
   pageType,
   totalCount,
   onPageChange,
+  pageSize: externalPageSize,
 }: PaginationProps) => {
-  const pageSize = PAGE_SIZE_MAP[pageType];
+  const pageSize = externalPageSize ?? PAGE_SIZE_MAP[pageType];
   const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
 
   const clamp = (page: number) => Math.min(Math.max(page, 1), totalPages);

--- a/src/widgets/main/ActivityList.tsx
+++ b/src/widgets/main/ActivityList.tsx
@@ -19,7 +19,7 @@ export const ActivityList = ({ activities = [], limit }: ActivityListProps) => {
 
   return (
     <div className="flex flex-col gap-10">
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-x-4 gap-y-8">
+      <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-5 gap-x-4 gap-y-8">
         {items.map((item) => (
           <ActivityCard key={item.id} {...item} />
         ))}

--- a/src/widgets/main/AllSection.tsx
+++ b/src/widgets/main/AllSection.tsx
@@ -1,4 +1,40 @@
-const AllSection = () => {
+import { useEffect, useState } from 'react';
+
+import { Pagination } from '@/shared/ui/Pagination/ui/Pagination';
+
+import { ActivityCardItem } from '../activity/activity-card';
+
+import { ActivityList } from './ActivityList';
+
+interface Props {
+  activities: ActivityCardItem[];
+}
+
+const AllSection = ({ activities }: Props) => {
+  const [pageSize, setPageSize] = useState(6);
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    const getPageSize = () => {
+      if (window.innerWidth >= 1024) return 15; // lg
+      if (window.innerWidth >= 768) return 4; // md
+      return 6; // sm
+    };
+
+    // 초기 계산
+    setPageSize(getPageSize());
+
+    const handleResize = () => setPageSize(getPageSize());
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const pageType = 'main';
+  const totalCount = activities.length;
+  const offset = (page - 1) * pageSize;
+
+  const pagedActivities = activities.slice(offset, offset + pageSize);
+
   return (
     <div className="flex flex-col items-center mt-5">
       {/* header */}
@@ -14,32 +50,20 @@ const AllSection = () => {
       </div>
       {/* body */}
       <div className="w-full">
-        <div className="flex gap-6 mb-5">
-          <div className="w-78 h-91.5 rounded-3xl border" />
-          <div className="w-78 h-91.5 rounded-3xl border" />
-          <div className="w-78 h-91.5 rounded-3xl border" />
-          <div className="w-78 h-91.5 rounded-3xl border" />
-          <div className="w-78 h-91.5 rounded-3xl border" />
-        </div>
-        <div className="flex gap-6 mb-5">
-          <div className="w-78 h-91.5 rounded-3xl border" />
-          <div className="w-78 h-91.5 rounded-3xl border" />
-          <div className="w-78 h-91.5 rounded-3xl border" />
-          <div className="w-78 h-91.5 rounded-3xl border" />
-
-          <div className="w-78 h-91.5 rounded-3xl border" />
-        </div>
-        <div className="flex gap-6 mb-5">
-          <div className="w-78 h-91.5 rounded-3xl border" />
-          <div className="w-78 h-91.5 rounded-3xl border" />
-          <div className="w-78 h-91.5 rounded-3xl border" />
-          <div className="w-78 h-91.5 rounded-3xl border" />
-
-          <div className="w-78 h-91.5 rounded-3xl border" />
-        </div>
+        <ActivityList activities={pagedActivities} />
       </div>
       {/* pagination */}
-      <div className="border w-76 h-10"></div>
+      <div className="mt-7.5">
+        <Pagination
+          currentPage={page}
+          pageType={pageType}
+          totalCount={totalCount}
+          pageSize={pageSize}
+          onPageChange={(nextPage) => {
+            setPage(nextPage);
+          }}
+        />
+      </div>
     </div>
   );
 };

--- a/src/widgets/main/MainContent.tsx
+++ b/src/widgets/main/MainContent.tsx
@@ -1,195 +1,32 @@
+'use client';
+
+import { ActivityListResponse } from '@/features/activity/activity-list/schema/activity-list.schema';
+import { useActivityOffsetList } from '@/features/activity/hooks/useActivityOffsetList';
 import Text from '@/shared/ui/Text';
-import type { ActivityCardItem } from '@/widgets/activity/model/activity-card.types';
-import { ActivityList } from '@/widgets/main';
 import MainHero from '@/widgets/main/MainHero';
 
+import AllSection from './AllSection';
 import PopularSection from './PopularSection';
 
 // TODO: 실제 데이터로 교체
-const BASE_ACTIVITY = {
-  category: '투어',
-  address: '서울특별시 강남구 테헤란로 427',
-  bannerImageUrl:
-    'https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1200&q=80',
-} satisfies Omit<
-  ActivityCardItem,
-  'id' | 'title' | 'rating' | 'reviewCount' | 'price' | 'imageUrl'
->;
+// const BASE_ACTIVITY = {
+//   category: '투어',
+//   address: '서울특별시 강남구 테헤란로 427',
+//   bannerImageUrl:
+//     'https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1200&q=80',
+// } satisfies Omit<
+//   ActivityCardItem,
+//   'id' | 'title' | 'rating' | 'reviewCount' | 'price' | 'imageUrl'
+// >;
 
-const MOCK_ACTIVITIES: ActivityCardItem[] = [
-  {
-    id: 1,
-    title: '함께 배우면 즐거운 스트릿 댄스',
-    rating: 3.9,
-    reviewCount: 108,
-    price: 42800,
-    imageUrl:
-      'https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1200&q=80',
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 2,
-    title: '연인과 사랑의 징검다리',
-    rating: 4.5,
-    reviewCount: 86,
-    price: 55000,
-    imageUrl:
-      'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80',
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 3,
-    title: '피오르 체험',
-    rating: 3.9,
-    reviewCount: 108,
-    price: 42800,
-    imageUrl:
-      'https://images.unsplash.com/photo-1473186578172-c141e6798cf4?auto=format&fit=crop&w=1200&q=80',
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 4,
-    title: '해안가 마을에서 1주일  ',
-    rating: 4.5,
-    reviewCount: 86,
-    price: 55000,
-    imageUrl:
-      'https://images.unsplash.com/photo-1508264165352-258859e62245?auto=format&fit=crop&w=1200&q=80',
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 5,
-    title: '부모님과 함께 갈대숲 체험',
-    rating: 4.5,
-    reviewCount: 86,
-    price: 55000,
-    imageUrl:
-      'https://images.unsplash.com/photo-1485968579580-b6d095142e6e?auto=format&fit=crop&w=1200&q=80',
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 6,
-    title: '함께 배우면 즐거운 스트릿 댄스',
-    rating: 3.9,
-    reviewCount: 108,
-    price: 42800,
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 7,
-    title: '연인과 사랑의 징검다리',
-    rating: 4.5,
-    reviewCount: 86,
-    price: 55000,
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 8,
-    title: '피오르 체험',
-    rating: 3.9,
-    reviewCount: 108,
-    price: 42800,
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 9,
-    title: '해안가 마을에서 1주일  ',
-    rating: 4.5,
-    reviewCount: 86,
-    price: 55000,
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 10,
-    title: '부모님과 함께 갈대숲 체험',
-    rating: 4.5,
-    reviewCount: 86,
-    price: 55000,
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 11,
-    title: '함께 배우면 즐거운 스트릿 댄스',
-    rating: 3.9,
-    reviewCount: 108,
-    price: 42800,
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 12,
-    title: '연인과 사랑의 징검다리',
-    rating: 4.5,
-    reviewCount: 86,
-    price: 55000,
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 13,
-    title: '피오르 체험',
-    rating: 3.9,
-    reviewCount: 108,
-    price: 42800,
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 14,
-    title: '해안가 마을에서 1주일  ',
-    rating: 4.5,
-    reviewCount: 86,
-    price: 55000,
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 15,
-    title: '부모님과 함께 갈대숲 체험',
-    rating: 4.5,
-    reviewCount: 86,
-    price: 55000,
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 16,
-    title: '함께 배우면 즐거운 스트릿 댄스',
-    rating: 3.9,
-    reviewCount: 108,
-    price: 42800,
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 17,
-    title: '연인과 사랑의 징검다리',
-    rating: 4.5,
-    reviewCount: 86,
-    price: 55000,
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 18,
-    title: '피오르 체험',
-    rating: 3.9,
-    reviewCount: 108,
-    price: 42800,
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 19,
-    title: '해안가 마을에서 1주일  ',
-    rating: 4.5,
-    reviewCount: 86,
-    price: 55000,
-    ...BASE_ACTIVITY,
-  },
-  {
-    id: 20,
-    title: '부모님과 함께 갈대숲 체험',
-    rating: 4.5,
-    reviewCount: 86,
-    price: 55000,
-    ...BASE_ACTIVITY,
-  },
-];
+const MainContent = ({ initialData }: { initialData: ActivityListResponse }) => {
+  const { activities } = useActivityOffsetList({
+    // isLoading, isError 상태 추가
+    page: 1,
+    size: 20,
+    initialData,
+  });
 
-const MainContent = () => {
   return (
     <main className="flex-1 mx-auto w-full max-w-350 px-6 py-26 md:px-10">
       <div className="mb-11">
@@ -219,7 +56,7 @@ const MainContent = () => {
           </Text.B18>
           {/* <AllSection /> */}
           <div className="mt-8">
-            <ActivityList activities={MOCK_ACTIVITIES} />
+            <AllSection activities={activities} />
           </div>
         </section>
       </div>

--- a/src/widgets/notification/NotificationModal.tsx
+++ b/src/widgets/notification/NotificationModal.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import { NotificationEntity } from '@/entities/notification/model/notification.type';
+import IC_Close from '@/shared/assets/icons/ic_delete.svg';
 import Button from '@/shared/ui/Button/Button';
 import Text from '@/shared/ui/Text';
 
 import NotificationCard from './NotificationCard';
 import { notificationModalStyles } from './NotificationModal.styles';
-
-import IC_Close from '@/shared/assets/icons/icon_delete.svg';
 
 type Props = {
   open: boolean;


### PR DESCRIPTION
## 📌 PR 개요

- main페이지의 전체 체험 리스트 조회

## 🔍 관련 이슈

- Closes #188

## 🔧 변경 유형

- [x] ✨ feat (새 기능 추가)

## ✨ 변경 사항
### `next.config.ts`
- `next/image`에서 최적화 가능하도록 허용할 `hostname`추가
### `main/page.tsx`
- `serverApi`로 초기 데이터를 받아와 `MainContent`로 넘김
### `activities/route.ts`
- activities를 가져오기 위한 `GET` 함수 추가
### `mapToActivityCardItem.ts`, `useActivityCursor(Offset)List.ts`
- 액티비티 리스트를 각각 cursor, offset method로 받아오는 커스텀 훅
- `mapToActivityCardItem.ts` : 공융 매퍼
- `useActivityCursorList.ts` : 스크롤로 아이템을 불러올 때 사용
- `useActivityOffsetList.ts` : 페이지네이션으로 아이템을 불러올 때 사용
- `useQuery`
    - `staleTime`을 5분으로 지정 - 실시간이 중요한 페이지가 아니라고 생각해 5분으로 잡았습니다. (현재 provider 기본은 1분)
    - `initialDate`를 추가하여 초기데이터 확보
    - `queryKey`에 각각 적절한 식별자를 넣어 캐시 공유
- ✔️ 현재 아직 메모이제이션은 추가를 하지 않은 상태
### `activity-card.types.ts`
- 액티비티카드용 타입 정의
### `activity-list.schema.ts`
- Activity관련 스키마 정의
- ✔️ `shared/schema/activity/activity.api.schema.ts`에 작성했다가 따로 옮겨봤는데 혹시 shared에 있는 게 맞는 것 같다면 다시 수정하겠습니다!
### `shared/constants/activity.ts`
- `ActivitySortValues`(정렬기준)추가
### `Pagination/`
- 반응형 사이징을 위해 `pageSize`를 추가
### `ActivityList.tsx`
- 피그마 디자인대로 `grid-cols` 수정
### `AllSection.tsx`
- [모든 체험]에 해당하는 부분을 그리는 섹션
- `{/* header */}`에 해당하는 부분은 다른 이슈에서 작업할 예정(태그 및 드롭다운 정렬)
- 리스트 및 페이지네이션 추가



## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- ~~ActivityCard 타입을 `feature/activity/model/activity-card.types.ts`에 추가해봤는데 현재 `useCreateActivity.ts`랑 같이 있어서 위치가 이상한 것 같은데 어디에 두는 게 좋을까요~~ -> 폴더 생성
- 현재 어떤 이미지는 보이고 어떤 이미지는 안보이는데 확인이 필요할 것 같습니다
