### PR TITLE
refactor: 로그인 인증 API 팀 규칙 적용 (#238)

### DIFF
--- a/src/app/api/refresh/route.ts
+++ b/src/app/api/refresh/route.ts
@@ -1,63 +1,66 @@
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
+import { respondError, toApiError } from '@/shared/api';
+import { serverApi } from '@/shared/api/server';
+import { tokenResponseSchema } from '@/shared/schema/auth/token-response.schema';
+
 export async function POST() {
   try {
     const cookieStore = await cookies();
-    const refreshToken = cookieStore.get('refreshToken');
+    const refreshToken = cookieStore.get('refreshToken')?.value;
 
+    // refreshToken 자체가 없으면 → 비로그인 상태
     if (!refreshToken) {
-      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+      throw new Error('Unauthorized');
     }
 
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/tokens`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${refreshToken.value}`,
-      },
+    // 토큰 재발급 요청
+    // 실패 시 serverApi 내부에서 ApiError throw
+    const {
+      data: { accessToken, refreshToken: newRefreshToken },
+    } = await serverApi.post({
+      path: '/auth/tokens',
+      body: { refreshToken },
+      schema: tokenResponseSchema,
     });
 
-    if (!res.ok) {
-      // 재발급 실패 → 로그아웃
-      const response = NextResponse.json({ message: 'Refresh failed' }, { status: 401 });
-
-      response.cookies.delete('accessToken');
-      response.cookies.delete('refreshToken');
-      return response;
-    }
-
-    const { accessToken, refreshToken: newRefreshToken } = await res.json();
-
-    const response = NextResponse.json({
-      success: true,
-      accessToken: newRefreshToken,
-    });
-
+    const response = NextResponse.json({ success: true });
     const isSecure = process.env.NODE_ENV === 'production';
 
-    // access token 갱신
+    // accessToken 갱신
     response.cookies.set('accessToken', accessToken, {
       httpOnly: true,
       secure: isSecure,
       sameSite: 'lax',
       path: '/',
-      maxAge: 60 * 60, //1시간
+      maxAge: 60 * 60,
     });
 
-    // refresh token이 새로 오면 교체 (rotation)
+    // refreshToken rotation (있을 때만 교체)
     if (newRefreshToken) {
       response.cookies.set('refreshToken', newRefreshToken, {
         httpOnly: true,
         secure: isSecure,
         sameSite: 'lax',
         path: '/',
-        maxAge: 60 * 60 * 24 * 7, //7일
+        maxAge: 60 * 60 * 24 * 7,
       });
     }
 
     return response;
-  } catch {
-    return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 });
+  } catch (e) {
+    // 재발급 실패 → 로그아웃
+    // (refresh 만료 / 위조 / 서버 거부 등)
+    // 쿠키 삭제가 필요한 경우 NextResponse를 직접 생성
+    const errorResponse = NextResponse.json(respondError(toApiError(e)).body, {
+      status: respondError(toApiError(e)).status,
+    });
+
+    // 재발급 실패 → 로그아웃
+    errorResponse.cookies.delete('accessToken');
+    errorResponse.cookies.delete('refreshToken');
+
+    return errorResponse;
   }
 }

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,20 +1,18 @@
 import { NextResponse } from 'next/server';
 
-import { fetchWithAuth } from '@/shared/lib/fetchWithAuth';
+import { respondError, toApiError } from '@/shared/api';
+import { serverApi } from '@/shared/api/server';
+import { userMeResponseSchema } from '@/shared/schema/user/user-me-response.schema';
 
 export const GET = async () => {
   try {
-    const res = await fetchWithAuth('/users/me', {
-      method: 'GET',
+    const { data: user } = await serverApi.get({
+      path: '/users/me',
+      schema: userMeResponseSchema,
     });
 
-    if (!res.ok) {
-      return NextResponse.json({ message: 'Unauthorized' }, { status: res.status });
-    }
-
-    const user = await res.json();
     return NextResponse.json(user);
-  } catch {
-    return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 });
+  } catch (e) {
+    return respondError(toApiError(e));
   }
 };

--- a/src/features/auth/model/useLoginSubmit.ts
+++ b/src/features/auth/model/useLoginSubmit.ts
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 
+import { isApiError } from '@/shared/api';
 import { LoginFormValues } from '@/shared/schema/auth';
 import { useModalStore } from '@/shared/stores/useModalStore';
 
@@ -11,21 +12,17 @@ export function useLoginSubmit() {
 
   return async (data: LoginFormValues) => {
     try {
-      const res = await fetch('/api/login', {
+      await fetch('/api/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
       });
 
-      if (!res.ok) {
-        openAlert('로그인에 실패했습니다.');
-        return;
-      }
-
       router.push('/');
     } catch (e) {
-      console.error(e); // **추후 수정** 임시에러 eslint 통과
-      openAlert('네트워크 연결 상태를 확인해주세요.');
+      if (isApiError(e)) {
+        openAlert(e.message);
+      }
     }
   };
 }

--- a/src/shared/schema/auth/login-request.schema.ts
+++ b/src/shared/schema/auth/login-request.schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const loginRequestSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
+
+export type LoginRequest = z.infer<typeof loginRequestSchema>;

--- a/src/shared/schema/auth/login-response.schema.ts
+++ b/src/shared/schema/auth/login-response.schema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const loginResponseSchema = z.object({
+  user: z.object({
+    id: z.number(),
+    email: z.string().email(),
+    nickname: z.string(),
+    profileImageUrl: z.string().nullable(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  }),
+  accessToken: z.string(),
+  refreshToken: z.string(),
+});
+
+export type LoginResponse = z.infer<typeof loginResponseSchema>;

--- a/src/shared/schema/auth/token-response.schema.ts
+++ b/src/shared/schema/auth/token-response.schema.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+
+export const tokenResponseSchema = z.object({
+  accessToken: z.string(),
+  refreshToken: z.string(),
+});

--- a/src/shared/schema/user/user-me-response.schema.ts
+++ b/src/shared/schema/user/user-me-response.schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const userMeResponseSchema = z.object({
+  id: z.number(),
+  email: z.string().email(),
+  nickname: z.string(),
+  profileImageUrl: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type UserMeResponse = z.infer<typeof userMeResponseSchema>;


### PR DESCRIPTION
## 📌 PR 개요

- 로그인 및 인증 관련 API를 팀 API 사용 표준(clientApi/serverApi, ApiError 기반) 에 맞게 리팩토링합니다.
- 기존 fetch, fetchWithAuth 기반 구현을 제거하고, BFF(App Route) 책임을 명확히 분리했습니다.
- 로그인 / 토큰 재발급 / 유저 조회 흐름을 일관된 에러 처리 패턴으로 통합합니다.
## 🔍 관련 이슈

- Closes #238

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [ ] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [x] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 로그인 App Route(/api/login)를 serverApi + schema + ApiError 패턴으로 리팩토링
- 토큰 재발급 App Route(/api/refresh)를 동일 패턴으로 정리 및 rotation 처리
- /api/users/me에서 fetchWithAuth 제거 후 serverApi 기반 조회로 변경
- 클라이언트 로그인 훅(useLoginSubmit)에서
res.ok, status 분기 제거 → ApiError 기준 UI 처리로 단순화

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [ ] 코드가 정상 동작함
- [ ] 빌드 및 실행 확인 완료
- [ ] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

<img width="1887" height="221" alt="image" src="https://github.com/user-attachments/assets/c023f388-c357-445f-9198-d82a332888c8" />

## 🤝 기타 참고 사항

- 에러 모달이 안나오고 있는데 일단 로그인은 되어서 로그인 필요하신분들 작업먼저 하라고 올립니다!
