### PR TITLE
fix: 카카오 로그인 오류 (#248)

### DIFF
--- a/src/app/api/auth/oauth/kakao/route.ts
+++ b/src/app/api/auth/oauth/kakao/route.ts
@@ -2,10 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { getBaseUrl } from '@/shared/api/core/url';
 
-const getRedirectPath = (_flow: string | null) => {
-  return '/main';
-};
-
 const getErrorRedirectPath = (flow: string | null) => {
   if (flow === 'signup') return '/signup?error=oauth';
   return '/login?error=oauth';
@@ -38,38 +34,36 @@ const createAuthRedirectResponse = (
 
   return response;
 };
-
-const KAKAO_TOKEN_URL = 'https://kauth.kakao.com/oauth/token';
-const KAKAO_USER_URL = 'https://kapi.kakao.com/v2/user/me';
+// const KAKAO_USER_URL = 'https://kapi.kakao.com/v2/user/me';
 
 // 카카오 닉네임 뽑아서 자동 회원가입으로 사용
-const getKakaoNickname = async (code: string) => {
-  const tokenParams = new URLSearchParams({
-    grant_type: 'authorization_code',
-    client_id: process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY ?? '',
-    redirect_uri: process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI ?? '',
-    code,
-  });
+// const getKakaoNickname = async (code: string) => {
+//   const tokenParams = new URLSearchParams({
+//     grant_type: 'authorization_code',
+//     client_id: process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY ?? '',
+//     redirect_uri: process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI ?? '',
+//     code,
+//   });
 
-  const tokenRes = await fetch(KAKAO_TOKEN_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: tokenParams.toString(),
-  });
+//   const tokenRes = await fetch(KAKAO_TOKEN_URL, {
+//     method: 'POST',
+//     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+//     body: tokenParams.toString(),
+//   });
 
-  if (!tokenRes.ok) return null;
+//   if (!tokenRes.ok) return null;
 
-  const { access_token: accessToken } = await tokenRes.json();
+//   const { access_token: accessToken } = await tokenRes.json();
 
-  const userRes = await fetch(KAKAO_USER_URL, {
-    headers: { Authorization: `Bearer ${accessToken}` },
-  });
+//   const userRes = await fetch(KAKAO_USER_URL, {
+//     headers: { Authorization: `Bearer ${accessToken}` },
+//   });
 
-  if (!userRes.ok) return null;
+//   if (!userRes.ok) return null;
 
-  const user = await userRes.json();
-  return user?.kakao_account?.profile?.nickname ?? user?.properties?.nickname ?? null;
-};
+//   const user = await userRes.json();
+//   return user?.kakao_account?.profile?.nickname ?? user?.properties?.nickname ?? null;
+// };
 
 export const GET = async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
@@ -81,8 +75,30 @@ export const GET = async (req: NextRequest) => {
   }
 
   try {
-    // BFF로 인가 코드 넘겨서 로그인 처리
-    const res = await fetch(`${getBaseUrl()}/oauth/sign-in/kakao`, {
+    if (state === 'signup') {
+      const signUpRes = await fetch(`${getBaseUrl()}/oauth/sign-up/kakao`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          nickname: `user_${Date.now()}`,
+          token: code,
+          redirectUri: process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI,
+        }),
+      });
+
+      if (signUpRes.ok) {
+        const { accessToken, refreshToken } = await signUpRes.json();
+        return createAuthRedirectResponse(req, '/main', accessToken, refreshToken);
+      }
+
+      if (signUpRes.status === 409) {
+        return NextResponse.redirect(new URL('/login?error=already_registered', req.url));
+      }
+
+      return NextResponse.redirect(new URL('/signup?error=oauth', req.url));
+    }
+
+    const signInRes = await fetch(`${getBaseUrl()}/oauth/sign-in/kakao`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -91,55 +107,16 @@ export const GET = async (req: NextRequest) => {
       }),
     });
 
-    if (!res.ok) {
-      await res.text();
-      if (res.status === 403) {
-        // 미가입이면 카카오 닉네임으로 자동 회원가입 시도
-        const nickname = (await getKakaoNickname(code)) ?? 'kakao_user';
-        const signUpRes = await fetch(`${getBaseUrl()}/oauth/sign-up/kakao`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            nickname,
-            token: code,
-            redirectUri: process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI,
-          }),
-        });
-
-        if (signUpRes.ok) {
-          const { accessToken, refreshToken } = await signUpRes.json();
-          return createAuthRedirectResponse(req, '/main', accessToken, refreshToken);
-        }
-
-        const signUpError = await signUpRes.text();
-
-        if (signUpRes.status === 409 || signUpError.includes('이미')) {
-          // 이미 가입된 케이스면 로그인 재시도
-          const retrySignInRes = await fetch(`${getBaseUrl()}/oauth/sign-in/kakao`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              token: code,
-              redirectUri: process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI,
-            }),
-          });
-
-          if (retrySignInRes.ok) {
-            const { accessToken, refreshToken } = await retrySignInRes.json();
-            return createAuthRedirectResponse(req, '/main', accessToken, refreshToken);
-          }
-          await retrySignInRes.text();
-        }
-
-        return NextResponse.redirect(new URL(getErrorRedirectPath(state), req.url));
-      }
-
-      return NextResponse.redirect(new URL(getErrorRedirectPath(state), req.url));
+    if (signInRes.ok) {
+      const { accessToken, refreshToken } = await signInRes.json();
+      return createAuthRedirectResponse(req, '/main', accessToken, refreshToken);
     }
 
-    const { accessToken, refreshToken } = await res.json();
-    // 로그인 성공이면 쿠키 굳히고 화면 이동
-    return createAuthRedirectResponse(req, getRedirectPath(state), accessToken, refreshToken);
+    if (signInRes.status === 403) {
+      return NextResponse.redirect(new URL('/signup?error=not_registered', req.url));
+    }
+
+    return NextResponse.redirect(new URL('/login?error=oauth', req.url));
   } catch {
     return NextResponse.redirect(new URL(getErrorRedirectPath(state), req.url));
   }

--- a/src/features/auth/ui/LoginForm/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm/LoginForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import { useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 
 import { getKakaoAuthUrl } from '@/features/auth/kakaoAuth';
@@ -16,6 +17,8 @@ import { useLoginSubmit } from '../../model/useLoginSubmit';
 import VisibleButton from './VisibleButton';
 
 const LoginForm = () => {
+  const searchParams = useSearchParams();
+  const error = searchParams.get('error');
   const [isVisible, setIsVisible] = useState(false);
   const [isCapsLockOn, setIsCapsLockOn] = useState(false);
 
@@ -84,7 +87,13 @@ const LoginForm = () => {
           <Divider className="absolute" />
           <p className="text-m16 relative bg-white px-4 text-gray-600">or</p>
         </div>
-
+        {error && (
+          <div className="p-3 rounded-md bg-red-50 text-red-600 text-sm">
+            {error === 'not_registered' &&
+              '가입되지 않은 계정입니다. 회원가입을 먼저 진행해주세요.'}
+            {error === 'oauth' && '카카오 로그인에 실패했습니다. 다시 시도해주세요.'}
+          </div>
+        )}
         <Button
           type="button"
           variant="secondary"

--- a/src/features/auth/ui/signup/SignupForm.tsx
+++ b/src/features/auth/ui/signup/SignupForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import { useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 
 import { getKakaoAuthUrl } from '@/features/auth/kakaoAuth';
@@ -15,6 +16,8 @@ import Label from '@/shared/ui/Label';
 import Text from '@/shared/ui/Text';
 
 export const SignupForm = () => {
+  const searchParams = useSearchParams();
+  const error = searchParams.get('error');
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
 
@@ -128,7 +131,12 @@ export const SignupForm = () => {
             SNS 계정으로 회원가입하기
           </Text.M16>
         </div>
-
+        {error && (
+          <div className="w-full p-3 mb-5 rounded-md bg-red-50 text-red-600 text-sm">
+            {error === 'already_registered' && '이미 가입된 계정입니다. 로그인해주세요.'}
+            {error === 'oauth' && '카카오 회원가입에 실패했습니다. 다시 시도해주세요.'}
+          </div>
+        )}
         <Button
           type="button"
           variant="secondary"


### PR DESCRIPTION
## 📌 PR 개요

- 카카오 인가 코드(code)는 일회용인데, 기존 코드에서 같은 code를 여러 번 사용하려고 시도했음, 그걸 해결

## 🔍 관련 이슈

- Closes #248

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [ ] ✨ feat (새 기능 추가)
- [x] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

기존 흐름:
1. /oauth/sign-in/kakao에 code 전송 → 백엔드가 code로 토큰 교환 (code 소진됨)
2. 403 응답 (미가입 유저)
3. getKakaoNickname(code) 호출 → 이미 사용된 code로 토큰 교환 시도 → 실패
4. /oauth/sign-up/kakao에 code 전송 → 또 실패
5. 결과: signup?error=oauth로 리다이렉트

변경:
[회원가입 버튼 클릭 시] state=signup
→ sign-up API 한 번만 호출 → 성공 시 /main, 실패 시 에러 페이지
[로그인 버튼 클릭 시] state=login  
→ sign-in API 한 번만 호출 → 성공 시 /main, 실패 시 에러 페이지

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [ ] 코드가 정상 동작함
- [ ] 빌드 및 실행 확인 완료
- [ ] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- 카카오 닉네임 자동 설정 기능은 제거됨 (code 일회성 때문에 불가). 현재는 user_${timestamp} 형태의 임시 닉네임으로 가입 후, 필요시 프로필 수정에서 변경하는 방식.
